### PR TITLE
Use the openMCT proxyUrl to get around CORS issues when connecting to Telemachus

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,7 +70,8 @@
         console.log('Proxying request to: ', req.query.url);
         req.pipe(request({
             url: req.query.url,
-            strictSSL: false
+            strictSSL: false,
+            qs: req.query
         }).on('error', next)).pipe(res);
     });
 

--- a/example/kerbal/bundle.js
+++ b/example/kerbal/bundle.js
@@ -54,7 +54,7 @@ define([
                 {
                     "key": "KERBAL_HTTP_API_URL",
                     "priority": "fallback",
-                    "value": "http://localhost:8085/telemachus/datalink"
+                    "value": "/proxyUrl?url=http://localhost:8085/telemachus/datalink"
                 }
             ],
             "runs": [


### PR DESCRIPTION
The extant proxyUrl provided by openMCT doesn't pass on query parameters, which prevented it working with Telemachus.
